### PR TITLE
Added option to specify number of simulations - Issue #11

### DIFF
--- a/builddatapack.sh
+++ b/builddatapack.sh
@@ -13,12 +13,35 @@
 # To run, open a terminal and enter:
 #   bash builddatapack.sh
 
+N_SIM=40 # Default value
+
+# Adding command line arguments via getopts
+while getopts "s:" opt;
+do
+  case ${opt} in
+    s )
+      N_SIM=$OPTARG
+      re_isanum='^[0-9]+$'
+      if ! [[ $N_SIM =~ $re_isanum ]] ; then
+        echo "Error: the number of simulations must be a positive whole number"
+        exit 1
+      elif [ $N_SIM -eq "0" ]; then
+        echo "Error: the number of simulations must be greater than 0"
+        exit 1
+      fi
+      ;;
+    ? )
+      echo "Usage: bash builddatapack.sh [-s N_SIM]"
+      exit 1
+      ;;
+  esac
+done
 
 # Generate timestamp variable
 pack=$(date +%Y%m%d-%H%M)
 
-# Run 40 simulations and display contents
-for i in {1..40}
+# Run N_SIM simulations and display contents
+for i in $(seq 1 $N_SIM);
 do
   # Run dms
   python3 dicemechanicsim.py 2>/dev/null


### PR DESCRIPTION
#### Reference Issues/PRs

This PR is to solve issue #11 

#### What does this implement? Explain your changes

I used the getopts command to introduce an optional command line argument (-s) to specify the number of simulations that the builddatapack.sh script will run, instead of the 40 that was set by default.

#### Any other comments?

Nothing else